### PR TITLE
Use type=int in pep8 add_arguments

### DIFF
--- a/discover_jenkins/tasks/run_pep8.py
+++ b/discover_jenkins/tasks/run_pep8.py
@@ -72,7 +72,7 @@ class Pep8Task(object):
         parser.add_argument("--pep8-ignore", dest="pep8-ignore",
             help="skip errors and warnings (e.g. E4,W)")
         parser.add_argument("--pep8-max-line-length",
-            dest="pep8-max-line-length", type='int',
+            dest="pep8-max-line-length", type=int,
             help="set maximum allowed line length (default: %d)" %
                  pep8.MAX_LINE_LENGTH)
         parser.add_argument("--pep8-rcfile", dest="pep8-rcfile",


### PR DESCRIPTION
type='int' is optparse-only syntax so far as I can tell
